### PR TITLE
feat: implement Obsidian publishing pipeline (export/sync/validate) and CI integration

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -48,8 +48,14 @@ jobs:
           ruby-version: 3   # reads from a '.ruby-version' or '.tools-version' file if 'ruby-version' is omitted
           bundler-cache: true
 
-      - name: Say Hello
-        run: echo "Hello! I am learning GitHub Actions."
+      - name: Validate publishing inputs
+        run: bash tools/publishing/validate.sh
+
+      - name: Export publishable notes
+        run: bash tools/publishing/export.sh
+
+      - name: Sync exported content to Jekyll dirs
+        run: bash tools/publishing/sync-to-jekyll.sh
 
       - name: Build site
         run: bundle exec jekyll b -d "_site${{ steps.pages.outputs.base_path }}"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Obsidian/_drafts
 Obsidian/.obsidian
 Obsidian/.trash
 admin
+vault/.obsidian/
+vault/.trash/
+vault/**/.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -187,6 +187,8 @@ exclude:
   - package*.json
   - .obsidian
   - .trash
+  - vault
+  - site-content
 # exclude 指定了 Jekyll 在构建站点时应该排除的文件和目录。
 
 jekyll-archives:

--- a/docs/publishing-pipeline.md
+++ b/docs/publishing-pipeline.md
@@ -1,0 +1,209 @@
+# Obsidian Vault 与博客发布内容分离方案（Jekyll + Chirpy + GitHub Pages）
+
+> 适用仓库：`JayChou404.github.io`（Chirpy 主题 + GitHub Pages Action）。
+
+## 1. 目标与现状
+
+当前仓库已经具备以下基础：
+
+- Jekyll 构建由 GitHub Actions 驱动，`bundle exec jekyll b` 后发布到 Pages。
+- `_config.yml` 中已排除 `.obsidian`、`.trash`，说明已有把 Obsidian 元数据排除出站点的意识。
+
+为了进一步实现“写作工作区（Vault）”和“线上发布内容（Jekyll 内容）”彻底分离，推荐采用**双目录+导出**模式：
+
+- `vault/`：仅用于 Obsidian 创作，不直接参与 Jekyll 构建。
+- `site-content/`：导出后的“可发布 Markdown 与资源”。
+- `_posts/`、`assets/img/posts/`：Jekyll 真正读取的内容目录（由导出脚本同步生成）。
+
+---
+
+## 2. 推荐目录结构
+
+> 下面结构可在当前仓库内落地；也可把 `vault/` 放在仓库外（更彻底隔离）。
+
+```text
+.
+├── .github/
+├── _config.yml
+├── _posts/                      # Jekyll 发布目录（由导出流程写入）
+├── assets/
+│   └── img/
+│       └── posts/              # 文章资源（图片、附件）发布目录
+├── tools/
+│   └── publishing/
+│       ├── export.sh           # 从 vault 导出到 site-content
+│       ├── sync-to-jekyll.sh   # 从 site-content 同步到 _posts/assets
+│       └── validate.sh         # 发布前校验
+├── site-content/               # 中间产物：仅含“可发布内容”
+│   ├── posts/
+│   └── assets/
+└── vault/                      # Obsidian 工作区（建议默认不发布）
+    ├── .obsidian/
+    ├── 00-Inbox/
+    ├── 10-Drafts/
+    ├── 20-Posts/
+    ├── 30-Notes/
+    ├── 90-Archive/
+    └── attachments/
+```
+
+### `vault/` 内建议分层
+
+- `00-Inbox/`：临时收集。
+- `10-Drafts/`：草稿（不发布）。
+- `20-Posts/`：候选发布文章。
+- `30-Notes/`：知识笔记（默认不发布）。
+- `attachments/`：原始附件池。
+
+---
+
+## 3. 发布筛选规则（核心）
+
+建议采用“**目录 + Front Matter + 白名单字段**”三重筛选，避免误发：
+
+1. **目录门禁**
+   - 仅扫描 `vault/20-Posts/`。
+   - 其余目录（`Drafts/Notes/Archive`）无条件跳过。
+
+2. **Front Matter 门禁**（建议）
+   - `publish: true` 才可导出。
+   - `date:` 必填；未填则阻断导出。
+   - `title:` 必填；为空则阻断导出。
+   - `tags/categories` 可选但建议规范。
+
+3. **文件名规则**
+   - 导出为 Jekyll 标准：`YYYY-MM-DD-slug.md`。
+   - `slug` 从英文标题或手工 `slug:` 字段生成，避免中文文件名导致链接不稳定。
+
+4. **内容规则**
+   - 禁止导出包含私密标记的文章（如 `private: true`、`sensitive: true`）。
+   - 可在校验阶段做关键字阻断（如身份证号、密钥模式等）。
+
+---
+
+## 4. 导出目录与同步路径
+
+建议分两步，保证可审计与可回滚：
+
+### Step A：Vault → `site-content/`
+
+- 文章导出到：`site-content/posts/`
+- 资源导出到：`site-content/assets/`
+- 该阶段完成：
+  - Front Matter 规范化
+  - Obsidian 链接改写（见下文）
+  - 资源去重与重命名
+
+### Step B：`site-content/` → Jekyll 目录
+
+- `site-content/posts/*.md` → `_posts/*.md`
+- `site-content/assets/**` → `assets/img/posts/**`
+
+> 优点：`site-content/` 作为“发布候选区”，可以在 PR 中直接 review。
+
+---
+
+## 5. 资源目录策略（图片/附件）
+
+建议采用“文章隔离目录”，减少重名冲突：
+
+```text
+assets/img/posts/
+└── 2026-02-13-obsidian-pipeline/
+    ├── cover.webp
+    ├── diagram-01.png
+    └── ref-table.csv
+```
+
+规则建议：
+
+- 每篇文章一个目录：`assets/img/posts/<post-slug>/`
+- 资源名做规范化：小写、短横线、去空格。
+- 大图导出时可自动压缩为 `webp`（可选）。
+- Obsidian 原始附件不直接引用，统一走发布目录路径。
+
+---
+
+## 6. 链接策略（Obsidian WikiLink → Jekyll URL）
+
+Obsidian 常见写法需在导出时转换：
+
+1. `[[文章标题]]`
+   - 转换为：`[文章标题]({% post_url yyyy-mm-dd-slug %})` 或最终 URL `/posts/slug/`
+
+2. `[[文章标题#小节]]`
+   - 转换为：`/posts/slug/#小节锚点`
+
+3. `![[image.png]]`
+   - 转换为：`![alt](/assets/img/posts/<post-slug>/image.png)`
+
+4. 相对链接 `./foo.md`
+   - 统一改写为站内 permalink。
+
+为降低复杂度，建议只支持以下“可发布链接集合”：
+
+- 指向 `vault/20-Posts/` 中已发布文章的内部链接。
+- 指向当前文章资源目录中的附件链接。
+
+其余链接在 `validate.sh` 中报错并阻断发布。
+
+---
+
+## 7. 回滚策略（Git + 发布流程）
+
+建议按“内容回滚”和“站点回滚”两层处理：
+
+### 7.1 内容回滚（首选）
+
+- 所有导出结果通过 PR 合并。
+- 发布异常时：
+  1. `git revert <bad_commit>` 回滚本次导出提交。
+  2. 触发 GitHub Pages Action 重新部署。
+
+### 7.2 站点快速回滚（紧急）
+
+- 在 `main` 维护最近可用 tag（如 `release-YYYYMMDD-HHMM`）。
+- 故障时直接把 `main` 回退到最近稳定 tag，再触发部署。
+
+### 7.3 预防性措施
+
+- 导出前执行：链接检查、Front Matter 校验、敏感词扫描。
+- Action 中保留 `htmlproofer`（仓库已有），避免坏链接进入生产。
+
+---
+
+## 8. 与当前仓库配置的衔接建议
+
+1. `_config.yml`
+   - 保留 `.obsidian`、`.trash` 的 `exclude`。
+   - 追加：`vault/`、`site-content/`（如果不希望中间产物被 Jekyll误处理）。
+
+2. GitHub Actions
+   - 在 `Build site` 前插入导出步骤：
+     - `tools/publishing/export.sh`
+     - `tools/publishing/sync-to-jekyll.sh`
+     - `tools/publishing/validate.sh`
+
+3. 本地工作流
+   - 写作：仅在 `vault/` 完成。
+   - 发布：执行一键脚本（导出→同步→校验→commit）。
+
+---
+
+## 9. 最小可执行流程（建议）
+
+```bash
+# 1) 从 vault 挑选 publish:true 的文章导出到 site-content
+bash tools/publishing/export.sh
+
+# 2) 同步到 _posts 与 assets/img/posts
+bash tools/publishing/sync-to-jekyll.sh
+
+# 3) 预发布校验
+bash tools/publishing/validate.sh
+
+# 4) 本地构建
+bundle exec jekyll b
+```
+
+如果你希望，我下一步可以基于这个文档直接给出 `export.sh / sync-to-jekyll.sh / validate.sh` 的可执行初版（兼容你当前 Chirpy 结构和 GitHub Pages Action）。

--- a/tools/publishing/export.sh
+++ b/tools/publishing/export.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 tools/publishing/publish.py export "$@"

--- a/tools/publishing/publish.py
+++ b/tools/publishing/publish.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+GENERATED_BY = "publish.py"
+ASSET_MARKER_FILE = ".generated_by_publish_py"
+
+WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+EMBED_RE = re.compile(r"!\[\[([^\]]+)\]\]")
+
+SENSITIVE_PATTERNS = [
+    ("aws_access_key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("private_key", re.compile(r"-----BEGIN (?:RSA|OPENSSH|EC|DSA) PRIVATE KEY-----")),
+    ("github_token", re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}")),
+    ("password_assignment", re.compile(r"(?i)\bpassword\b\s*[:=]\s*\S+")),
+    ("token_assignment", re.compile(r"(?i)\btoken\b\s*[:=]\s*\S+")),
+    ("cookie_assignment", re.compile(r"(?i)\bcookie\b\s*[:=]\s*\S+")),
+    ("ssh_private", re.compile(r"(?i)id_rsa")),
+]
+
+
+@dataclass
+class Note:
+    source_path: Path
+    frontmatter: Dict[str, object]
+    body: str
+    title: str
+    slug: str
+    date_raw: str
+    date_prefix: str
+    post_id: str
+    output_post_path: Path
+    assets_dir: Path
+
+
+def parse_frontmatter(text: str) -> Tuple[Dict[str, object], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+
+    raw = text[4:end]
+    body = text[end + 5 :]
+    fm: Dict[str, object] = {}
+    for line in raw.splitlines():
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.lower() in {"true", "false"}:
+            fm[key] = value.lower() == "true"
+        elif value.startswith("[") and value.endswith("]"):
+            items = [v.strip().strip('"\'') for v in value[1:-1].split(",") if v.strip()]
+            fm[key] = items
+        else:
+            fm[key] = value.strip('"\'')
+    return fm, body
+
+
+def parse_date_prefix(value: str) -> Optional[str]:
+    value = value.strip()
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        return value
+    try:
+        normal = value.replace("T", " ")
+        normal = re.sub(r"\s+[+-]\d{2}:?\d{2}$", "", normal)
+        normal = normal.split("+")[0].split("Z")[0].strip()
+        dt = datetime.fromisoformat(normal)
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9\u4e00-\u9fff\-\s]", "", value).strip().lower()
+    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def load_notes(vault_posts_dir: Path, site_dir: Path) -> Tuple[List[Note], List[str]]:
+    errors: List[str] = []
+    notes: List[Note] = []
+
+    for source in sorted(vault_posts_dir.rglob("*.md")):
+        text = source.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(text)
+
+        if not fm.get("publish", False):
+            continue
+        if fm.get("private", False) or fm.get("sensitive", False):
+            continue
+
+        title = str(fm.get("title", "")).strip()
+        date_raw = str(fm.get("date", "")).strip()
+        slug = str(fm.get("slug", "")).strip() or slugify(title)
+
+        if not title:
+            errors.append(f"{source}: missing front matter title")
+            continue
+        if not date_raw:
+            errors.append(f"{source}: missing front matter date")
+            continue
+        date_prefix = parse_date_prefix(date_raw)
+        if not date_prefix:
+            errors.append(f"{source}: invalid date format `{date_raw}`")
+            continue
+        if not slug:
+            errors.append(f"{source}: missing or invalid slug")
+            continue
+
+        post_id = f"{date_prefix}-{slug}"
+        output_post_path = site_dir / "posts" / f"{post_id}.md"
+        assets_dir = site_dir / "assets" / slug
+        notes.append(
+            Note(
+                source_path=source,
+                frontmatter=fm,
+                body=body,
+                title=title,
+                slug=slug,
+                date_raw=date_raw,
+                date_prefix=date_prefix,
+                post_id=post_id,
+                output_post_path=output_post_path,
+                assets_dir=assets_dir,
+            )
+        )
+
+    seen_post_ids: Dict[str, Path] = {}
+    seen_slugs: Dict[str, Path] = {}
+    for note in notes:
+        if note.post_id in seen_post_ids:
+            errors.append(f"post_id conflict: {note.source_path} conflicts with {seen_post_ids[note.post_id]}")
+        seen_post_ids[note.post_id] = note.source_path
+        if note.slug in seen_slugs:
+            errors.append(f"slug conflict: {note.source_path} conflicts with {seen_slugs[note.slug]}")
+        seen_slugs[note.slug] = note.source_path
+
+    return notes, errors
+
+
+def resolve_asset(note: Note, ref: str, vault_dir: Path) -> Optional[Path]:
+    ref_name = ref.split("|")[0].strip()
+    candidates = [
+        note.source_path.parent / ref_name,
+        vault_dir / "attachments" / ref_name,
+        vault_dir / ref_name,
+    ]
+    for path in candidates:
+        if path.exists() and path.is_file():
+            return path
+    return None
+
+
+def convert_content(note: Note, title_map: Dict[str, Note], vault_dir: Path, errors: List[str]) -> Tuple[str, List[Tuple[Path, Path]]]:
+    copy_plan: List[Tuple[Path, Path]] = []
+    body = note.body
+
+    def replace_embed(match: re.Match[str]) -> str:
+        raw = match.group(1).strip()
+        asset = resolve_asset(note, raw, vault_dir)
+        if not asset:
+            errors.append(f"{note.source_path}: missing embed asset `{raw}`")
+            return match.group(0)
+        note.assets_dir.mkdir(parents=True, exist_ok=True)
+        dest = note.assets_dir / asset.name
+        copy_plan.append((asset, dest))
+        alt = asset.stem
+        return f"![{alt}](/assets/img/posts/{note.slug}/{asset.name})"
+
+    body = EMBED_RE.sub(replace_embed, body)
+
+    def replace_wikilink(match: re.Match[str]) -> str:
+        raw = match.group(1).strip()
+        if raw.startswith("http"):
+            return match.group(0)
+
+        if "|" in raw:
+            target, alias = raw.split("|", 1)
+            alias = alias.strip()
+        else:
+            target, alias = raw, raw
+        target = target.strip()
+
+        anchor = ""
+        if "#" in target:
+            target, section = target.split("#", 1)
+            anchor = f"#{section.strip()}"
+
+        linked = title_map.get(target)
+        if not linked:
+            errors.append(f"{note.source_path}: unresolved wikilink `[[{raw}]]`")
+            return f"[{alias}]"
+
+        return f"[{alias}]({{% post_url {linked.post_id} %}}{anchor})"
+
+    body = WIKILINK_RE.sub(replace_wikilink, body)
+    return body, copy_plan
+
+
+def render_frontmatter(note: Note) -> str:
+    inherit_keys = ["categories", "tags", "description", "image", "toc", "comments", "pin"]
+    lines = [
+        "---",
+        "layout: post",
+        f'title: "{note.title}"',
+        f"date: {note.date_raw}",
+        f"slug: {note.slug}",
+        f"generated_by: {GENERATED_BY}",
+        f"source_path: {note.source_path.as_posix()}",
+    ]
+    for key in inherit_keys:
+        if key in note.frontmatter:
+            value = note.frontmatter[key]
+            if isinstance(value, list):
+                lines.append(f"{key}: [{', '.join(str(v) for v in value)}]")
+            elif isinstance(value, bool):
+                lines.append(f"{key}: {'true' if value else 'false'}")
+            else:
+                lines.append(f"{key}: {value}")
+    lines.append("---")
+    return "\n".join(lines) + "\n\n"
+
+
+def write_if_changed(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return
+    path.write_text(content, encoding="utf-8")
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    vault_dir = Path(args.vault_dir)
+    site_dir = Path(args.site_dir)
+    posts_dir = vault_dir / "20-Posts"
+
+    notes, errors = load_notes(posts_dir, site_dir)
+    if errors:
+        print("Export failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    title_map = {note.title: note for note in notes}
+
+    site_posts = site_dir / "posts"
+    site_assets = site_dir / "assets"
+    shutil.rmtree(site_posts, ignore_errors=True)
+    shutil.rmtree(site_assets, ignore_errors=True)
+    site_posts.mkdir(parents=True, exist_ok=True)
+    site_assets.mkdir(parents=True, exist_ok=True)
+
+    index = {}
+    export_errors: List[str] = []
+
+    for note in sorted(notes, key=lambda n: n.post_id):
+        converted_body, copy_plan = convert_content(note, title_map, vault_dir, export_errors)
+        front = render_frontmatter(note)
+        write_if_changed(note.output_post_path, front + converted_body.strip() + "\n")
+
+        if copy_plan:
+            note.assets_dir.mkdir(parents=True, exist_ok=True)
+            (note.assets_dir / ASSET_MARKER_FILE).write_text(GENERATED_BY, encoding="utf-8")
+            for src, dst in sorted(copy_plan, key=lambda x: x[0].as_posix()):
+                if not dst.exists() or src.read_bytes() != dst.read_bytes():
+                    shutil.copy2(src, dst)
+
+        index[note.title] = {
+            "title": note.title,
+            "source_path": note.source_path.as_posix(),
+            "post_id": note.post_id,
+            "output_post_path": note.output_post_path.as_posix(),
+            "assets_dir": note.assets_dir.as_posix(),
+        }
+
+    if export_errors:
+        print("Export failed:")
+        for err in export_errors:
+            print(f"- {err}")
+        return 1
+
+    index_path = site_dir / ".index.json"
+    write_if_changed(index_path, json.dumps(index, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+    print(f"Exported {len(notes)} post(s) into {site_dir}")
+    return 0
+
+
+def read_index(site_dir: Path) -> Dict[str, dict]:
+    index_path = site_dir / ".index.json"
+    if not index_path.exists():
+        return {}
+    return json.loads(index_path.read_text(encoding="utf-8"))
+
+
+def is_generated_post(path: Path) -> bool:
+    if not path.exists():
+        return False
+    fm, _ = parse_frontmatter(path.read_text(encoding="utf-8"))
+    return fm.get("generated_by") == GENERATED_BY
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    site_dir = Path(args.site_dir)
+    posts_dir = Path(args.posts_dir)
+    assets_dir = Path(args.assets_dir)
+
+    source_posts = site_dir / "posts"
+    source_assets = site_dir / "assets"
+
+    if not source_posts.exists():
+        print(f"sync failed: missing source posts dir {source_posts}")
+        return 1
+
+    index = read_index(site_dir)
+    managed_posts = {Path(data["output_post_path"]).name for data in index.values()}
+    for post_file in sorted(posts_dir.glob("*.md")):
+        if is_generated_post(post_file) and post_file.name not in managed_posts:
+            post_file.unlink()
+
+    for src in sorted(source_posts.glob("*.md")):
+        if not is_generated_post(src):
+            continue
+        dst = posts_dir / src.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if not dst.exists() or src.read_text(encoding="utf-8") != dst.read_text(encoding="utf-8"):
+            shutil.copy2(src, dst)
+
+    managed_asset_slugs = {Path(data["assets_dir"]).name for data in index.values()}
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    for child in sorted(assets_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        marker = child / ASSET_MARKER_FILE
+        if marker.exists() and child.name not in managed_asset_slugs:
+            shutil.rmtree(child)
+
+    if source_assets.exists():
+        for src_dir in sorted(source_assets.iterdir()):
+            if not src_dir.is_dir():
+                continue
+            dst_dir = assets_dir / src_dir.name
+            if dst_dir.exists():
+                shutil.rmtree(dst_dir)
+            shutil.copytree(src_dir, dst_dir)
+
+    print("Sync completed")
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    vault_dir = Path(args.vault_dir)
+    posts_dir = vault_dir / "20-Posts"
+
+    notes, errors = load_notes(posts_dir, Path(args.site_dir))
+    title_map = {note.title: note for note in notes}
+
+    for note in notes:
+        convert_content(note, title_map, vault_dir, errors)
+        raw = note.source_path.read_text(encoding="utf-8")
+        for name, pattern in SENSITIVE_PATTERNS:
+            if pattern.search(raw):
+                errors.append(f"{note.source_path}: sensitive pattern matched `{name}`")
+
+    if errors:
+        print("Validation failed:")
+        for err in sorted(errors):
+            print(f"- {err}")
+        return 1
+
+    print(f"Validation passed for {len(notes)} post(s)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Obsidian -> Jekyll publishing pipeline")
+    parser.add_argument("--vault-dir", default="vault", help="Path to vault root")
+    parser.add_argument("--site-dir", default="site-content", help="Path to site-content root")
+    parser.add_argument("--posts-dir", default="_posts", help="Path to Jekyll posts directory")
+    parser.add_argument("--assets-dir", default="assets/img/posts", help="Path to Jekyll assets directory")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("export", help="Export publishable notes into site-content")
+    sub.add_parser("sync", help="Sync exported content into _posts/assets")
+    sub.add_parser("validate", help="Validate publishable notes")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "export":
+        return cmd_export(args)
+    if args.command == "sync":
+        return cmd_sync(args)
+    if args.command == "validate":
+        return cmd_validate(args)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/publishing/sync-to-jekyll.sh
+++ b/tools/publishing/sync-to-jekyll.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 tools/publishing/publish.py sync "$@"

--- a/tools/publishing/validate.sh
+++ b/tools/publishing/validate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 tools/publishing/publish.py validate "$@"


### PR DESCRIPTION
### Motivation
- Separate the Obsidian vault from Jekyll input to avoid accidental publishing of drafts and private notes.
- Automate Obsidian→Chirpy export, link/asset conversion and front-matter normalization to make selective publishing one-step from the vault.
- Add safety guards for a public repo by scanning for sensitive patterns and by only managing files that were generated by the tool.

### Description
- Add `tools/publishing/publish.py` implementing three subcommands: `export` (scan `vault/20-Posts`, require `publish: true`, convert wikilinks and embeds, copy assets, write `site-content/.index.json`), `sync` (sync `site-content` → `_posts` and `assets/img/posts` while only deleting files/assets marked as generated), and `validate` (front matter checks, slug/post conflicts, unresolved links, missing embeds, sensitive-pattern scanning).
- Add thin shell wrappers `tools/publishing/{export.sh,sync-to-jekyll.sh,validate.sh}` to standardize local/CI invocation and use a generated marker (`generated_by` front matter and an asset marker file) to avoid modifying manual content.
- Integrate the pipeline into GitHub Actions by inserting `validate -> export -> sync` before `bundle exec jekyll b`, and update `_config.yml` and `.gitignore` to exclude `vault` and `site-content` from Jekyll and to ignore Obsidian metadata.
- Add `docs/publishing-pipeline.md` explaining the recommended directory layout, publishing filter rules, export/sync paths, resource strategy, link rewriting approach and rollback guidance.

### Testing
- Ran `python3 tools/publishing/publish.py --help` which printed the CLI help successfully.
- Ran `python3 -m py_compile tools/publishing/publish.py` which completed with no syntax errors.
- Ran `python3 tools/publishing/publish.py validate` which returned "Validation passed for 0 post(s)" because there were no publishable notes in this environment.
- Ran the pipeline end-to-end locally (`validate`, `export`, `sync`) which completed successfully and produced `site-content` (exported 0 posts in this repo context), confirming the commands execute in the repository environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f156ecc10832fb0c58c54e1f5e258)